### PR TITLE
201811 ali add fpga pci rescan

### DIFF
--- a/device/alibaba/x86_64-alibaba_as13-32h-cl-r0/plugins/fwmgrutil.py
+++ b/device/alibaba/x86_64-alibaba_as13-32h-cl-r0/plugins/fwmgrutil.py
@@ -8,6 +8,7 @@ import requests
 import os
 import pexpect
 import base64
+import time
 
 try:
     from sonic_fwmgr.fwgmr_base import FwMgrUtilBase
@@ -42,6 +43,30 @@ class FwMgrUtil(FwMgrUtilBase):
             return 'None'
         else:
             return raw_data.strip()
+
+    def __fpga_pci_rescan(self):
+        """
+        An sequence to trigger FPGA to load new configuration after upgrade.
+        """
+        fpga_pci_device_remove = '/sys/devices/pci0000:00/0000:00:1c.0/0000:09:00.0/remove'
+        parent_pci_device_rescan = '/sys/devices/pci0000:00/0000:00:1c.0/rescan'
+        cmd = 'modprobe -r switchboard_fpga'
+        os.system(cmd)
+        cmd = 'echo 1 > %s' % fpga_pci_device_remove
+        rc = os.system(cmd)
+        if rc > 0:
+            return rc
+        cmd = 'echo 0xa10a 0 > /sys/devices/platform/%s.cpldb/setreg' % self.platform_name
+        rc = os.system(cmd)
+        if rc > 0:
+            return rc
+        time.sleep(10)
+        cmd = 'echo 1 > %s' % parent_pci_device_rescan
+        rc = os.system(cmd)
+        if rc > 0:
+            return rc
+        os.system('modprobe switchboard_fpga')
+        return 0
 
     def get_bmc_pass(self):
         with open(self.bmc_pwd_path) as file:
@@ -254,8 +279,16 @@ class FwMgrUtil(FwMgrUtilBase):
                     break
                 if output:
                     print(output.strip())
-            rc = process.poll()
-            return True
+
+            if process.returncode == 0:
+                rc = self.__fpga_pci_rescan()
+                if rc == 0:
+                    return True
+                else:
+                    print("Fails to load new FPGA firmware")
+                    return False
+            else:
+                return False
 
         elif 'cpld' in fw_type:
             command = 'ispvm ' + fw_path

--- a/device/alibaba/x86_64-alibaba_as13-48f8h-cl-r0/plugins/fwmgrutil.py
+++ b/device/alibaba/x86_64-alibaba_as13-48f8h-cl-r0/plugins/fwmgrutil.py
@@ -8,6 +8,7 @@ import requests
 import os
 import pexpect
 import base64
+import time
 
 try:
     from sonic_fwmgr.fwgmr_base import FwMgrUtilBase
@@ -42,6 +43,30 @@ class FwMgrUtil(FwMgrUtilBase):
             return 'None'
         else:
             return raw_data.strip()
+
+    def __fpga_pci_rescan(self):
+        """
+        An sequence to trigger FPGA to load new configuration after upgrade.
+        """
+        fpga_pci_device_remove = '/sys/devices/pci0000:00/0000:00:1c.0/0000:09:00.0/remove'
+        parent_pci_device_rescan = '/sys/devices/pci0000:00/0000:00:1c.0/rescan'
+        cmd = 'modprobe -r switchboard_fpga'
+        os.system(cmd)
+        cmd = 'echo 1 > %s' % fpga_pci_device_remove
+        rc = os.system(cmd)
+        if rc > 0:
+            return rc
+        cmd = 'echo 0xa10a 0 > /sys/devices/platform/%s.cpldb/setreg' % self.platform_name
+        rc = os.system(cmd)
+        if rc > 0:
+            return rc
+        time.sleep(10)
+        cmd = 'echo 1 > %s' % parent_pci_device_rescan
+        rc = os.system(cmd)
+        if rc > 0:
+            return rc
+        os.system('modprobe switchboard_fpga')
+        return 0
 
     def get_bmc_pass(self):
         with open(self.bmc_pwd_path) as file:
@@ -254,8 +279,16 @@ class FwMgrUtil(FwMgrUtilBase):
                     break
                 if output:
                     print(output.strip())
-            rc = process.poll()
-            return True
+
+            if process.returncode == 0:
+                rc = self.__fpga_pci_rescan()
+                if rc == 0:
+                    return True
+                else:
+                    print("Fails to load new FPGA firmware")
+                    return False
+            else:
+                return False
 
         elif 'cpld' in fw_type:
             command = 'ispvm ' + fw_path


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Implement function to reload FPGA PCI device after finish online upgrade without power cycling the device.
**- How I did it**
Add a function piggy back in FPGA upgrade in fwmgrutil plugins.
**- How to verify it**
Run FPGA online upgrade as usual and check for new version number after finished.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- No power cycling need for FPGA online upgrade.


**- A picture of a cute animal (not mandatory but encouraged)**