### PR TITLE
[devices/alibaba] Add cpu c-state limit in SONiC Linux boot argument

### DIFF
--- a/device/alibaba/x86_64-alibaba_as13-32h-cl-r0/installer.conf
+++ b/device/alibaba/x86_64-alibaba_as13-32h-cl-r0/installer.conf
@@ -1,1 +1,2 @@
 CONSOLE_SPEED=9600
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="processor.max_cstate=1 intel_idle.max_cstate=0"

--- a/device/alibaba/x86_64-alibaba_as13-48f8h-cl-r0/installer.conf
+++ b/device/alibaba/x86_64-alibaba_as13-48f8h-cl-r0/installer.conf
@@ -1,1 +1,2 @@
 CONSOLE_SPEED=9600
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="processor.max_cstate=1 intel_idle.max_cstate=0"

--- a/device/alibaba/x86_64-alibaba_as23-128h-cl-r0/installer.conf
+++ b/device/alibaba/x86_64-alibaba_as23-128h-cl-r0/installer.conf
@@ -1,1 +1,2 @@
 CONSOLE_SPEED=9600
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="processor.max_cstate=1 intel_idle.max_cstate=0"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Add device-specific configuration on Alibaba Fishbone32, Fishbone48, and Phalanx.
The config is limiting CPU c-state to prevent hang up.

**- How I did it**
Add the ONIE_PLATFORM_EXTRA_CMDLINE_LINUX argument in device specific installer.conf

**- How to verify it**
`cat /proc/cmdline` and check the arguments

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
* Add cpu cstate config on Fishbone32, Fishbone48, and Phalanx device.

**- A picture of a cute animal (not mandatory but encouraged)**
